### PR TITLE
Removed the usage of `lazy_static`

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -52,20 +52,10 @@ dependencies = [
  "bitflags",
  "elf",
  "flanterm",
- "lazy_static",
  "limine",
  "rustc-demangle",
- "spin 0.10.0",
+ "spin",
  "talc",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -104,12 +94,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,7 +9,6 @@ bitflags = "2.9.1"
 elf = { version = "0.7", default-features = false, features = ["nightly"] }
 flanterm = "0.0.2"
 limine = "0.5"
-lazy_static = { version = "1.0", features = ["spin_no_std"] }
 rustc-demangle = "0.1"
 spin = "0.10.0"
 talc = "4.4.3"

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -9,6 +9,7 @@ use core::{
     marker::PhantomData,
     ops::{Index, IndexMut},
 };
+use spin::Lazy;
 
 #[allow(dead_code)]
 #[repr(C, align(16))]
@@ -311,14 +312,14 @@ impl_handler_func_type!(HandlerFuncWithErrCode);
 impl_handler_func_type!(DivergingHandlerFunc);
 impl_handler_func_type!(DivergingHandlerFuncWithErrCode);
 
-lazy_static::lazy_static! {
-    static ref IDT: InterruptDescriptorTable = {
-        let mut idt = InterruptDescriptorTable::new();
-        idt.double_fault.set_handler_fn(exceptions::double_fault_handler);
-        idt.page_fault.set_handler_fn(exceptions::page_fault_handler);
-        idt
-    };
-}
+static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
+    let mut idt = InterruptDescriptorTable::new();
+    idt.double_fault
+        .set_handler_fn(exceptions::double_fault_handler);
+    idt.page_fault
+        .set_handler_fn(exceptions::page_fault_handler);
+    idt
+});
 
 pub fn init() {
     IDT.load();

--- a/kernel/src/arch/x86_64/writer.rs
+++ b/kernel/src/arch/x86_64/writer.rs
@@ -1,6 +1,6 @@
 use crate::util::option_to_c_void;
 use core::{fmt, ptr};
-use spin::Mutex;
+use spin::{Lazy, Mutex};
 
 pub struct FlantermContext(pub *mut flanterm::sys::flanterm_context);
 unsafe impl Send for FlantermContext {}
@@ -45,11 +45,9 @@ pub fn init() {
     crate::trace!("Initialized Flanterm context");
 }
 
-lazy_static::lazy_static! {
-    pub static ref FLANTERM_CTX: Mutex<FlantermContext> =
-        Mutex::new(FlantermContext(ptr::null_mut()));
-    pub static ref WRITER: Mutex<FlantermWriter> = Mutex::new(FlantermWriter {});
-}
+pub static FLANTERM_CTX: Lazy<Mutex<FlantermContext>> =
+    Lazy::new(|| Mutex::new(FlantermContext(ptr::null_mut())));
+pub static WRITER: Lazy<Mutex<FlantermWriter>> = Lazy::new(|| Mutex::new(FlantermWriter {}));
 
 pub struct FlantermWriter {}
 


### PR DESCRIPTION
This PR removes the dependency on the `lazy_static` crate and replaces it with `spin::Lazy` for lazy initialization. This reduces external dependencies and simplifies the code.

The modified code includes the Flanterm context and the IDT, which are now initialized lazily through `spin::Lazy`.